### PR TITLE
Don't publish the python SDK

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -1,12 +1,10 @@
 provider: local
 major-version: 0
-lint: true
 providerDefaultBranch: main
 makeTemplate: bridged
 publishRegistry: false
 env:
   LOCAL_TOKEN: ${{ secrets.LOCAL_TOKEN }}
-team: ecosystem
 plugins:
   - name: aws
     version: "6.14.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -324,7 +324,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.12
+      uses: pulumi/pulumi-package-publisher@749cccccfef0c5dbc04e4c48d8c115b7f2b19207
+      with:
+        sdk: 'all,!python'
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -269,7 +269,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.12
+      uses: pulumi/pulumi-package-publisher@749cccccfef0c5dbc04e4c48d8c115b7f2b19207
+      with:
+        sdk: 'all,!python'
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.12
+      uses: pulumi/pulumi-package-publisher@749cccccfef0c5dbc04e4c48d8c115b7f2b19207
+      with:
+        sdk: 'all,!python'
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
This PR tests out https://github.com/pulumi/pulumi-package-publisher/pull/21.

I'm going to merge as is. The changes will be removed by the next "update workflows" PR.